### PR TITLE
adding --oc arg to enforce use oc client

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -280,3 +280,12 @@ func (t *CustomTool) IsInteractive(args map[string]any) (bool, error) {
 func (t *ToolCall) GetTool() Tool {
 	return t.tool
 }
+
+// NewToolCall creates a ToolCall (for use in other packages)
+func NewToolCall(tool Tool, name string, arguments map[string]any) *ToolCall {
+	return &ToolCall{
+		tool:      tool,
+		name:      name,
+		arguments: arguments,
+	}
+}


### PR DESCRIPTION
Adding --oc arg to enforce oc command with kubectl-ai

Usage :  
kubectl-ai --oc --mode=<model name>
>>> get the status of the node
  Running: oc get nodes
.
.
. 